### PR TITLE
build: update to Java 21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v3
       - name: Test
         run: ./gradlew check jacocoTestReport

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-FROM bellsoft/liberica-native-image-kit-container:jdk-17-nik-22-musl AS builder
+FROM container-registry.oracle.com/graalvm/native-image-community:21 AS builder
 
 WORKDIR /build
 
 # Copy the source code into the image for building
 COPY . /build
 
+# Install xargs (part of findutils) which is required by Gradle.
+RUN microdnf install findutils
+
 # Build
 RUN ./gradlew nativeCompile
 
 # The deployment Image
-FROM bellsoft/alpaquita-linux-base:stream-musl
+FROM container-registry.oracle.com/os/oraclelinux:9-slim
 
 EXPOSE 8080
 EXPOSE 8081

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {


### PR DESCRIPTION
This won't work yet, as liberica is not available for Java 21 yet.

Update: I use the GraalVM and runtime images from Oracle instead of Bellsoft now, as these support Java 21.